### PR TITLE
Fixed listtransactions argument for missing/null account parameter

### DIFF
--- a/CoinRpc/BitcoinClient.php
+++ b/CoinRpc/BitcoinClient.php
@@ -641,6 +641,8 @@ class BitcoinClient extends AbstractClient
         $args = array();
         if (null !== $account) {
             $args[] = $account;
+        } else {
+            $args[] = '*';
         }
 
         if (null !== $count) {


### PR DESCRIPTION
I could only get listtransactions() to work by supplying '*' for the $account parameter if a null/default account is used/passed.